### PR TITLE
Fix parts with subpath

### DIFF
--- a/Assets/LDraw-Importer/Editor/Scripts/LDrawConfig.cs
+++ b/Assets/LDraw-Importer/Editor/Scripts/LDrawConfig.cs
@@ -110,6 +110,10 @@ namespace LDraw
                 if (!file.Contains(".meta"))
                 {
                     string fileName = file.Replace(_BasePartsPath, "").Split('.')[0];
+
+                    //If part has subpath, remove subpath
+                    if (fileName.Contains("\\"))
+                        fileName = fileName.Split('\\')[1];
                    
                     if (!_Parts.ContainsKey(fileName))
                         _Parts.Add(fileName, file);


### PR DESCRIPTION
When trying to import a model with a part that has a sub-file reference located in a subfolder of parts folder, you receive the error "Missing part or wrong part ! Find it in the url from debug console"

It does it when there are sub-file references even when the file does exist in the subfolder.
When getting the filename for the key in the _Parts dictionary, the extra path is not taken into account.

Fixed issue in the LDrawConfig.cs file in the InitParts() method. If the part is a sub-file and therefore in a child folder, an extra step is required to remove the subpath from the complete path to obtain the filename by itself.

This assumes only single depth subfolders are used in the Parts folder per LDraw specifications.